### PR TITLE
added migration "deploy_proxy"

### DIFF
--- a/build/contracts/Cats.json
+++ b/build/contracts/Cats.json
@@ -64,12 +64,12 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.5.8+commit.23d335f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_toSet\",\"type\":\"uint256\"}],\"name\":\"setNumberOfCats\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"_initialized\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getNumberOFCats\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol\":\"Cats\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol\":{\"keccak256\":\"0xac438cd6dc67c9f0154706bdf0e2d85ad62efbef5c37ce9a16531bfb2cab7630\",\"urls\":[\"bzzr://f43063c72ff854ff91ad8cd7fb5e1fa79d235a59124df6a2b79577c081ac5c2b\"]},\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":{\"keccak256\":\"0x89dacc345a67a37189c28a709477950ad5dfe7be2ddfff04c868fb19241a9444\",\"urls\":[\"bzzr://7b05bc88eb86b249580288d13d35cafecb19324c6b4f9bc031b4a12d8b944a13\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b5033600560006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101f9806100616000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c8063254fa81a146100515780633072cf601461007f5780638da5cb5b146100a1578063aad621fd146100eb575b600080fd5b61007d6004803603602081101561006757600080fd5b8101908080359060200190929190505050610109565b005b61008761014f565b604051808215151515815260200191505060405180910390f35b6100a9610162565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100f3610188565b6040518082815260200191505060405180910390f35b80600060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390208190555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60008060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390205490509056fea165627a7a723058201eb5aa322a1f105e17d33b8a62025e60604649dfd23179a09f59d09f31d34e640029",
-  "deployedBytecode": "0x608060405234801561001057600080fd5b506004361061004c5760003560e01c8063254fa81a146100515780633072cf601461007f5780638da5cb5b146100a1578063aad621fd146100eb575b600080fd5b61007d6004803603602081101561006757600080fd5b8101908080359060200190929190505050610109565b005b61008761014f565b604051808215151515815260200191505060405180910390f35b6100a9610162565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100f3610188565b6040518082815260200191505060405180910390f35b80600060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390208190555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60008060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390205490509056fea165627a7a723058201eb5aa322a1f105e17d33b8a62025e60604649dfd23179a09f59d09f31d34e640029",
-  "sourceMap": "58:362:0:-;;;169:47;8:9:-1;5:2;;;30:1;27;20:12;5:2;169:47:0;203:10;195:5;;:18;;;;;;;;;;;;;;;;;;58:362;;;;;;",
-  "deployedSourceMap": "58:362:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;58:362:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;325:93;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;325:93:0;;;;;;;;;;;;;;;;;:::i;:::-;;287:24:2;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;265:20;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;222:98:0;;;:::i;:::-;;;;;;;;;;;;;;;;;;;325:93;405:6;382:12;:20;;;;;;;;;;;;;;;;;;;;;;;;:29;;;;325:93;:::o;287:24:2:-;;;;;;;;;;;;;:::o;265:20::-;;;;;;;;;;;;;:::o;222:98:0:-;268:7;293:12;:20;;;;;;;;;;;;;;;;;;;;;;;;;286:27;;222:98;:::o",
-  "source": "pragma solidity >=0.4.22 <0.9.0;\n\nimport\"./Storage.sol\";\n\ncontract Cats is Storage{\n\n    modifier onlyOwner{\n        require(msg.sender == owner);\n        _;\n    }\n    \nconstructor() public{\n    owner = msg.sender;\n}\n\n    function getNumberOFCats()public view returns(uint256){\n        return _uintStorage[\"Cats\"];\n    }\n    function setNumberOfCats(uint256 _toSet)public {\n        _uintStorage[\"Cats\"] = _toSet;\n    }\n}",
+  "metadata": "{\"compiler\":{\"version\":\"0.5.8+commit.23d335f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_toSet\",\"type\":\"uint256\"}],\"name\":\"setNumberOfCats\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"_initialized\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getNumberOFCats\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol\":\"Cats\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol\":{\"keccak256\":\"0x190448ec17c29363006561ad856515cb5f29aa4a237bd0d7141d24c08d2e964a\",\"urls\":[\"bzzr://603b978fc076ab65fd50497abf293e6a9481fe2770e6b55a73ebc8a67736a176\"]},\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":{\"keccak256\":\"0x1f47ada269b6e5d1cd53d5ceca0b2e77d55cc9b5c78b4f81607b5c942b56ad2e\",\"urls\":[\"bzzr://f26ea6721e2b8416eb7b48b59145fdbba66c881937b0ad3ad700cd8bdea0f514\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b5033600560006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101f9806100616000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c8063254fa81a146100515780633072cf601461007f5780638da5cb5b146100a1578063aad621fd146100eb575b600080fd5b61007d6004803603602081101561006757600080fd5b8101908080359060200190929190505050610109565b005b61008761014f565b604051808215151515815260200191505060405180910390f35b6100a9610162565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100f3610188565b6040518082815260200191505060405180910390f35b80600060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390208190555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60008060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390205490509056fea165627a7a7230582047e7df519bc182f40267308a01460666ed2c58d6ac15f18f0dc5c2fdc43eeea30029",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b506004361061004c5760003560e01c8063254fa81a146100515780633072cf601461007f5780638da5cb5b146100a1578063aad621fd146100eb575b600080fd5b61007d6004803603602081101561006757600080fd5b8101908080359060200190929190505050610109565b005b61008761014f565b604051808215151515815260200191505060405180910390f35b6100a9610162565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100f3610188565b6040518082815260200191505060405180910390f35b80600060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390208190555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60008060405180807f4361747300000000000000000000000000000000000000000000000000000000815250600401905090815260200160405180910390205490509056fea165627a7a7230582047e7df519bc182f40267308a01460666ed2c58d6ac15f18f0dc5c2fdc43eeea30029",
+  "sourceMap": "50:362:0:-;;;161:47;8:9:-1;5:2;;;30:1;27;20:12;5:2;161:47:0;195:10;187:5;;:18;;;;;;;;;;;;;;;;;;50:362;;;;;;",
+  "deployedSourceMap": "50:362:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;50:362:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;317:93;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;317:93:0;;;;;;;;;;;;;;;;;:::i;:::-;;278:24:3;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;256:20;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;214:98:0;;;:::i;:::-;;;;;;;;;;;;;;;;;;;317:93;397:6;374:12;:20;;;;;;;;;;;;;;;;;;;;;;;;:29;;;;317:93;:::o;278:24:3:-;;;;;;;;;;;;;:::o;256:20::-;;;;;;;;;;;;;:::o;214:98:0:-;260:7;285:12;:20;;;;;;;;;;;;;;;;;;;;;;;;;278:27;;214:98;:::o",
+  "source": "pragma solidity ^0.5.2;\n\nimport \"./Storage.sol\";\n\ncontract Cats is Storage{\n\n    modifier onlyOwner{\n        require(msg.sender == owner);\n        _;\n    }\n    \nconstructor() public{\n    owner = msg.sender;\n}\n\n    function getNumberOFCats()public view returns(uint256){\n        return _uintStorage[\"Cats\"];\n    }\n    function setNumberOfCats(uint256 _toSet)public {\n        _uintStorage[\"Cats\"] = _toSet;\n    }\n}",
   "sourcePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol",
   "ast": {
     "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol",
@@ -85,15 +85,12 @@
         "id": 1,
         "literals": [
           "solidity",
-          ">=",
-          "0.4",
-          ".22",
-          "<",
-          "0.9",
-          ".0"
+          "^",
+          "0.5",
+          ".2"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:32:0"
+        "src": "0:23:0"
       },
       {
         "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
@@ -101,8 +98,8 @@
         "id": 2,
         "nodeType": "ImportDirective",
         "scope": 48,
-        "sourceUnit": 108,
-        "src": "34:22:0",
+        "sourceUnit": 158,
+        "src": "25:23:0",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -115,20 +112,20 @@
               "id": 3,
               "name": "Storage",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 107,
-              "src": "75:7:0",
+              "referencedDeclaration": 157,
+              "src": "67:7:0",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_Storage_$107",
+                "typeIdentifier": "t_contract$_Storage_$157",
                 "typeString": "contract Storage"
               }
             },
             "id": 4,
             "nodeType": "InheritanceSpecifier",
-            "src": "75:7:0"
+            "src": "67:7:0"
           }
         ],
         "contractDependencies": [
-          107
+          157
         ],
         "contractKind": "contract",
         "documentation": null,
@@ -136,7 +133,7 @@
         "id": 47,
         "linearizedBaseContracts": [
           47,
-          107
+          157
         ],
         "name": "Cats",
         "nodeType": "ContractDefinition",
@@ -145,7 +142,7 @@
             "body": {
               "id": 14,
               "nodeType": "Block",
-              "src": "107:56:0",
+              "src": "99:56:0",
               "statements": [
                 {
                   "expression": {
@@ -170,8 +167,8 @@
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 122,
-                            "src": "125:3:0",
+                            "referencedDeclaration": 172,
+                            "src": "117:3:0",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
@@ -185,7 +182,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "125:10:0",
+                          "src": "117:10:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -199,14 +196,14 @@
                           "name": "owner",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 104,
-                          "src": "139:5:0",
+                          "referencedDeclaration": 154,
+                          "src": "131:5:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "125:19:0",
+                        "src": "117:19:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -224,11 +221,11 @@
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        125,
-                        126
+                        175,
+                        176
                       ],
-                      "referencedDeclaration": 125,
-                      "src": "117:7:0",
+                      "referencedDeclaration": 175,
+                      "src": "109:7:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -242,7 +239,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "117:28:0",
+                    "src": "109:28:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -250,12 +247,12 @@
                   },
                   "id": 12,
                   "nodeType": "ExpressionStatement",
-                  "src": "117:28:0"
+                  "src": "109:28:0"
                 },
                 {
                   "id": 13,
                   "nodeType": "PlaceholderStatement",
-                  "src": "155:1:0"
+                  "src": "147:1:0"
                 }
               ]
             },
@@ -267,16 +264,16 @@
               "id": 5,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "107:0:0"
+              "src": "99:0:0"
             },
-            "src": "89:74:0",
+            "src": "81:74:0",
             "visibility": "internal"
           },
           {
             "body": {
               "id": 23,
               "nodeType": "Block",
-              "src": "189:27:0",
+              "src": "181:27:0",
               "statements": [
                 {
                   "expression": {
@@ -292,8 +289,8 @@
                       "name": "owner",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 104,
-                      "src": "195:5:0",
+                      "referencedDeclaration": 154,
+                      "src": "187:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -309,8 +306,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 122,
-                        "src": "203:3:0",
+                        "referencedDeclaration": 172,
+                        "src": "195:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -324,13 +321,13 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "203:10:0",
+                      "src": "195:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address_payable",
                         "typeString": "address payable"
                       }
                     },
-                    "src": "195:18:0",
+                    "src": "187:18:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -338,7 +335,7 @@
                   },
                   "id": 22,
                   "nodeType": "ExpressionStatement",
-                  "src": "195:18:0"
+                  "src": "187:18:0"
                 }
               ]
             },
@@ -353,16 +350,16 @@
               "id": 16,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "180:2:0"
+              "src": "172:2:0"
             },
             "returnParameters": {
               "id": 17,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "189:0:0"
+              "src": "181:0:0"
             },
             "scope": 47,
-            "src": "169:47:0",
+            "src": "161:47:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -371,7 +368,7 @@
             "body": {
               "id": 33,
               "nodeType": "Block",
-              "src": "276:44:0",
+              "src": "268:44:0",
               "statements": [
                 {
                   "expression": {
@@ -382,8 +379,8 @@
                       "name": "_uintStorage",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 86,
-                      "src": "293:12:0",
+                      "referencedDeclaration": 136,
+                      "src": "285:12:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                         "typeString": "mapping(string memory => uint256)"
@@ -400,7 +397,7 @@
                       "kind": "string",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "306:6:0",
+                      "src": "298:6:0",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_stringliteral_a30fa43b6859f0269a191818c6875eae578387c7a5a49d4e46568fec752b6fc0",
@@ -413,7 +410,7 @@
                     "isPure": false,
                     "lValueRequested": false,
                     "nodeType": "IndexAccess",
-                    "src": "293:20:0",
+                    "src": "285:20:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -422,7 +419,7 @@
                   "functionReturnParameters": 28,
                   "id": 32,
                   "nodeType": "Return",
-                  "src": "286:27:0"
+                  "src": "278:27:0"
                 }
               ]
             },
@@ -437,7 +434,7 @@
               "id": 25,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "246:2:0"
+              "src": "238:2:0"
             },
             "returnParameters": {
               "id": 28,
@@ -449,7 +446,7 @@
                   "name": "",
                   "nodeType": "VariableDeclaration",
                   "scope": 34,
-                  "src": "268:7:0",
+                  "src": "260:7:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -460,7 +457,7 @@
                     "id": 26,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "268:7:0",
+                    "src": "260:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -470,10 +467,10 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "267:9:0"
+              "src": "259:9:0"
             },
             "scope": 47,
-            "src": "222:98:0",
+            "src": "214:98:0",
             "stateMutability": "view",
             "superFunction": null,
             "visibility": "public"
@@ -482,7 +479,7 @@
             "body": {
               "id": 45,
               "nodeType": "Block",
-              "src": "372:46:0",
+              "src": "364:46:0",
               "statements": [
                 {
                   "expression": {
@@ -500,8 +497,8 @@
                         "name": "_uintStorage",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 86,
-                        "src": "382:12:0",
+                        "referencedDeclaration": 136,
+                        "src": "374:12:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                           "typeString": "mapping(string memory => uint256)"
@@ -518,7 +515,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "395:6:0",
+                        "src": "387:6:0",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_a30fa43b6859f0269a191818c6875eae578387c7a5a49d4e46568fec752b6fc0",
@@ -531,7 +528,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "382:20:0",
+                      "src": "374:20:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -546,13 +543,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 36,
-                      "src": "405:6:0",
+                      "src": "397:6:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "382:29:0",
+                    "src": "374:29:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -560,7 +557,7 @@
                   },
                   "id": 44,
                   "nodeType": "ExpressionStatement",
-                  "src": "382:29:0"
+                  "src": "374:29:0"
                 }
               ]
             },
@@ -581,7 +578,7 @@
                   "name": "_toSet",
                   "nodeType": "VariableDeclaration",
                   "scope": 46,
-                  "src": "350:14:0",
+                  "src": "342:14:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -592,7 +589,7 @@
                     "id": 35,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "350:7:0",
+                    "src": "342:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -602,26 +599,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "349:16:0"
+              "src": "341:16:0"
             },
             "returnParameters": {
               "id": 38,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "372:0:0"
+              "src": "364:0:0"
             },
             "scope": 47,
-            "src": "325:93:0",
+            "src": "317:93:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 48,
-        "src": "58:362:0"
+        "src": "50:362:0"
       }
     ],
-    "src": "0:420:0"
+    "src": "0:412:0"
   },
   "legacyAST": {
     "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Cats.sol",
@@ -637,15 +634,12 @@
         "id": 1,
         "literals": [
           "solidity",
-          ">=",
-          "0.4",
-          ".22",
-          "<",
-          "0.9",
-          ".0"
+          "^",
+          "0.5",
+          ".2"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:32:0"
+        "src": "0:23:0"
       },
       {
         "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
@@ -653,8 +647,8 @@
         "id": 2,
         "nodeType": "ImportDirective",
         "scope": 48,
-        "sourceUnit": 108,
-        "src": "34:22:0",
+        "sourceUnit": 158,
+        "src": "25:23:0",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -667,20 +661,20 @@
               "id": 3,
               "name": "Storage",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 107,
-              "src": "75:7:0",
+              "referencedDeclaration": 157,
+              "src": "67:7:0",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_Storage_$107",
+                "typeIdentifier": "t_contract$_Storage_$157",
                 "typeString": "contract Storage"
               }
             },
             "id": 4,
             "nodeType": "InheritanceSpecifier",
-            "src": "75:7:0"
+            "src": "67:7:0"
           }
         ],
         "contractDependencies": [
-          107
+          157
         ],
         "contractKind": "contract",
         "documentation": null,
@@ -688,7 +682,7 @@
         "id": 47,
         "linearizedBaseContracts": [
           47,
-          107
+          157
         ],
         "name": "Cats",
         "nodeType": "ContractDefinition",
@@ -697,7 +691,7 @@
             "body": {
               "id": 14,
               "nodeType": "Block",
-              "src": "107:56:0",
+              "src": "99:56:0",
               "statements": [
                 {
                   "expression": {
@@ -722,8 +716,8 @@
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 122,
-                            "src": "125:3:0",
+                            "referencedDeclaration": 172,
+                            "src": "117:3:0",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
@@ -737,7 +731,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "125:10:0",
+                          "src": "117:10:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -751,14 +745,14 @@
                           "name": "owner",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 104,
-                          "src": "139:5:0",
+                          "referencedDeclaration": 154,
+                          "src": "131:5:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "125:19:0",
+                        "src": "117:19:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -776,11 +770,11 @@
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        125,
-                        126
+                        175,
+                        176
                       ],
-                      "referencedDeclaration": 125,
-                      "src": "117:7:0",
+                      "referencedDeclaration": 175,
+                      "src": "109:7:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -794,7 +788,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "117:28:0",
+                    "src": "109:28:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -802,12 +796,12 @@
                   },
                   "id": 12,
                   "nodeType": "ExpressionStatement",
-                  "src": "117:28:0"
+                  "src": "109:28:0"
                 },
                 {
                   "id": 13,
                   "nodeType": "PlaceholderStatement",
-                  "src": "155:1:0"
+                  "src": "147:1:0"
                 }
               ]
             },
@@ -819,16 +813,16 @@
               "id": 5,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "107:0:0"
+              "src": "99:0:0"
             },
-            "src": "89:74:0",
+            "src": "81:74:0",
             "visibility": "internal"
           },
           {
             "body": {
               "id": 23,
               "nodeType": "Block",
-              "src": "189:27:0",
+              "src": "181:27:0",
               "statements": [
                 {
                   "expression": {
@@ -844,8 +838,8 @@
                       "name": "owner",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 104,
-                      "src": "195:5:0",
+                      "referencedDeclaration": 154,
+                      "src": "187:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -861,8 +855,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 122,
-                        "src": "203:3:0",
+                        "referencedDeclaration": 172,
+                        "src": "195:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -876,13 +870,13 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "203:10:0",
+                      "src": "195:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address_payable",
                         "typeString": "address payable"
                       }
                     },
-                    "src": "195:18:0",
+                    "src": "187:18:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -890,7 +884,7 @@
                   },
                   "id": 22,
                   "nodeType": "ExpressionStatement",
-                  "src": "195:18:0"
+                  "src": "187:18:0"
                 }
               ]
             },
@@ -905,16 +899,16 @@
               "id": 16,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "180:2:0"
+              "src": "172:2:0"
             },
             "returnParameters": {
               "id": 17,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "189:0:0"
+              "src": "181:0:0"
             },
             "scope": 47,
-            "src": "169:47:0",
+            "src": "161:47:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -923,7 +917,7 @@
             "body": {
               "id": 33,
               "nodeType": "Block",
-              "src": "276:44:0",
+              "src": "268:44:0",
               "statements": [
                 {
                   "expression": {
@@ -934,8 +928,8 @@
                       "name": "_uintStorage",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 86,
-                      "src": "293:12:0",
+                      "referencedDeclaration": 136,
+                      "src": "285:12:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                         "typeString": "mapping(string memory => uint256)"
@@ -952,7 +946,7 @@
                       "kind": "string",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "306:6:0",
+                      "src": "298:6:0",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_stringliteral_a30fa43b6859f0269a191818c6875eae578387c7a5a49d4e46568fec752b6fc0",
@@ -965,7 +959,7 @@
                     "isPure": false,
                     "lValueRequested": false,
                     "nodeType": "IndexAccess",
-                    "src": "293:20:0",
+                    "src": "285:20:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -974,7 +968,7 @@
                   "functionReturnParameters": 28,
                   "id": 32,
                   "nodeType": "Return",
-                  "src": "286:27:0"
+                  "src": "278:27:0"
                 }
               ]
             },
@@ -989,7 +983,7 @@
               "id": 25,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "246:2:0"
+              "src": "238:2:0"
             },
             "returnParameters": {
               "id": 28,
@@ -1001,7 +995,7 @@
                   "name": "",
                   "nodeType": "VariableDeclaration",
                   "scope": 34,
-                  "src": "268:7:0",
+                  "src": "260:7:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1012,7 +1006,7 @@
                     "id": 26,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "268:7:0",
+                    "src": "260:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1022,10 +1016,10 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "267:9:0"
+              "src": "259:9:0"
             },
             "scope": 47,
-            "src": "222:98:0",
+            "src": "214:98:0",
             "stateMutability": "view",
             "superFunction": null,
             "visibility": "public"
@@ -1034,7 +1028,7 @@
             "body": {
               "id": 45,
               "nodeType": "Block",
-              "src": "372:46:0",
+              "src": "364:46:0",
               "statements": [
                 {
                   "expression": {
@@ -1052,8 +1046,8 @@
                         "name": "_uintStorage",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 86,
-                        "src": "382:12:0",
+                        "referencedDeclaration": 136,
+                        "src": "374:12:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                           "typeString": "mapping(string memory => uint256)"
@@ -1070,7 +1064,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "395:6:0",
+                        "src": "387:6:0",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_a30fa43b6859f0269a191818c6875eae578387c7a5a49d4e46568fec752b6fc0",
@@ -1083,7 +1077,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "382:20:0",
+                      "src": "374:20:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1098,13 +1092,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 36,
-                      "src": "405:6:0",
+                      "src": "397:6:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "382:29:0",
+                    "src": "374:29:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1112,7 +1106,7 @@
                   },
                   "id": 44,
                   "nodeType": "ExpressionStatement",
-                  "src": "382:29:0"
+                  "src": "374:29:0"
                 }
               ]
             },
@@ -1133,7 +1127,7 @@
                   "name": "_toSet",
                   "nodeType": "VariableDeclaration",
                   "scope": 46,
-                  "src": "350:14:0",
+                  "src": "342:14:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1144,7 +1138,7 @@
                     "id": 35,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "350:7:0",
+                    "src": "342:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1154,26 +1148,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "349:16:0"
+              "src": "341:16:0"
             },
             "returnParameters": {
               "id": 38,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "372:0:0"
+              "src": "364:0:0"
             },
             "scope": 47,
-            "src": "325:93:0",
+            "src": "317:93:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 48,
-        "src": "58:362:0"
+        "src": "50:362:0"
       }
     ],
-    "src": "0:420:0"
+    "src": "0:412:0"
   },
   "compiler": {
     "name": "solc",
@@ -1181,7 +1175,7 @@
   },
   "networks": {},
   "schemaVersion": "3.0.16",
-  "updatedAt": "2021-03-05T11:51:14.963Z",
+  "updatedAt": "2021-03-05T13:32:49.390Z",
   "devdoc": {
     "methods": {}
   },

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -863,9 +863,16 @@
     "name": "solc",
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
-  "networks": {},
+  "networks": {
+    "5777": {
+      "events": {},
+      "links": {},
+      "address": "0xCF8794F649B14405a363bBF754221E533a5B2858",
+      "transactionHash": "0xcea7afd506da66b427cf223679a2934a64d2dfe7d6306efc2d42c39f57c320db"
+    }
+  },
   "schemaVersion": "3.0.16",
-  "updatedAt": "2021-03-05T11:51:14.965Z",
+  "updatedAt": "2021-03-05T13:32:49.393Z",
   "devdoc": {
     "methods": {}
   },

--- a/build/contracts/Proxy.json
+++ b/build/contracts/Proxy.json
@@ -1,0 +1,1343 @@
+{
+  "contractName": "Proxy",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "_initialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "_currentAddress",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "upgrade",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "metadata": "{\"compiler\":{\"version\":\"0.5.8+commit.23d335f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_newAddress\",\"type\":\"address\"}],\"name\":\"upgrade\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"_initialized\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_currentAddress\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"fallback\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Proxy.sol\":\"Proxy\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Proxy.sol\":{\"keccak256\":\"0xd8e1eca962fc7decce44b64d237cb93c83926f569bd8791521fe8d8415e19952\",\"urls\":[\"bzzr://68ea243387dbc265bfdc467300c811e8e90d313c0eac463ec0a3dfdedd636ecc\"]},\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":{\"keccak256\":\"0x1f47ada269b6e5d1cd53d5ceca0b2e77d55cc9b5c78b4f81607b5c942b56ad2e\",\"urls\":[\"bzzr://f26ea6721e2b8416eb7b48b59145fdbba66c881937b0ad3ad700cd8bdea0f514\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b506040516020806103398339810180604052602081101561003057600080fd5b810190808051906020019092919050505080600660006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550506102a7806100926000396000f3fe6080604052600436106100345760003560e01c80630900f010146101275780633072cf60146101785780638da5cb5b146101a7575b6000600660009054906101000a900473ffffffffffffffffffffffffffffffffffffffff169050600073ffffffffffffffffffffffffffffffffffffffff16600660009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614156100b757600080fd5b60606000368080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f820116905080830192505050505050509050600080825160208401855af43d604051816000823e8260008114610123578282f35b8282fd5b34801561013357600080fd5b506101766004803603602081101561014a57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506101fe565b005b34801561018457600080fd5b5061018d610242565b604051808215151515815260200191505060405180910390f35b3480156101b357600080fd5b506101bc610255565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b80600660006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a7230582016ca48cb9008157f5d2df12e1abe6b1b9ef82d5871303755f35d82e28a45d4610029",
+  "deployedBytecode": "0x6080604052600436106100345760003560e01c80630900f010146101275780633072cf60146101785780638da5cb5b146101a7575b6000600660009054906101000a900473ffffffffffffffffffffffffffffffffffffffff169050600073ffffffffffffffffffffffffffffffffffffffff16600660009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614156100b757600080fd5b60606000368080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f820116905080830192505050505050509050600080825160208401855af43d604051816000823e8260008114610123578282f35b8282fd5b34801561013357600080fd5b506101766004803603602081101561014a57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506101fe565b005b34801561018457600080fd5b5061018d610242565b604051808215151515815260200191505060405180910390f35b3480156101b357600080fd5b506101bc610255565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b80600660006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050565b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a7230582016ca48cb9008157f5d2df12e1abe6b1b9ef82d5871303755f35d82e28a45d4610029",
+  "sourceMap": "50:902:2:-;;;110:94;8:9:-1;5:2;;;30:1;27;20:12;5:2;110:94:2;;;;;;;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;110:94:2;;;;;;;;;;;;;;;;181:15;164:14;;:32;;;;;;;;;;;;;;;;;;110:94;50:902;;;;;;",
+  "deployedSourceMap": "50:902:2:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;467:22;492:14;;;;;;;;;;;467:39;;550:1;524:28;;:14;;;;;;;;;;;:28;;;;516:37;;;;;;563:17;583:8;;563:28;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;93:3;85:6;81:16;74:27;137:4;133:9;126:4;121:3;117:14;113:30;106:37;;169:3;161:6;157:16;147:26;;563:28:2;;;;;;;;740:1;737;730:4;724:11;717:4;711;707:15;691:14;686:3;673:69;763:14;803:4;797:11;840:4;837:1;832:3;817:28;861:6;881:1;876:26;;;;932:4;927:3;920:17;876:26;896:4;891:3;884:17;210:91;;8:9:-1;5:2;;;30:1;27;20:12;5:2;210:91:2;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;210:91:2;;;;;;;;;;;;;;;;;;;:::i;:::-;;278:24:3;;8:9:-1;5:2;;;30:1;27;20:12;5:2;278:24:3;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;256:20;;8:9:-1;5:2;;;30:1;27;20:12;5:2;256:20:3;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;210:91:2;283:11;266:14;;:28;;;;;;;;;;;;;;;;;;210:91;:::o;278:24:3:-;;;;;;;;;;;;;:::o;256:20::-;;;;;;;;;;;;;:::o",
+  "source": "pragma solidity ^0.5.2;\n\nimport \"./Storage.sol\";\n\ncontract Proxy is Storage{\n    address currentAddress;\n\n    constructor(address _currentAddress) public {\n        currentAddress = _currentAddress;\n\n    }\n\n    function upgrade (address _newAddress) public {\n        currentAddress = _newAddress;\n    }\n    // fallback function\n    // dont have name, in case someone have called nonexsited function. Then this will be called.\n    function() payable external {\n        address implementation = currentAddress;\n        require(currentAddress != address(0));\n        bytes memory data = msg.data;\n\n    //DELEGATECALL EVERY FUNCTION CALL\n       assembly {\n        let result := delegatecall(gas, implementation, add(data, 0x20), mload(data), 0, 0)\n        let size := returndatasize\n        let ptr := mload(0x40)\n        returndatacopy(ptr, 0, size)\n        switch result\n        case 0 {revert(ptr, size)}\n        default {return(ptr, size)}\n    }\n    }\n}",
+  "sourcePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Proxy.sol",
+  "ast": {
+    "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Proxy.sol",
+    "exportedSymbols": {
+      "Proxy": [
+        130
+      ]
+    },
+    "id": 131,
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 82,
+        "literals": [
+          "solidity",
+          "^",
+          "0.5",
+          ".2"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "0:23:2"
+      },
+      {
+        "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
+        "file": "./Storage.sol",
+        "id": 83,
+        "nodeType": "ImportDirective",
+        "scope": 131,
+        "sourceUnit": 158,
+        "src": "25:23:2",
+        "symbolAliases": [],
+        "unitAlias": ""
+      },
+      {
+        "baseContracts": [
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 84,
+              "name": "Storage",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 157,
+              "src": "68:7:2",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Storage_$157",
+                "typeString": "contract Storage"
+              }
+            },
+            "id": 85,
+            "nodeType": "InheritanceSpecifier",
+            "src": "68:7:2"
+          }
+        ],
+        "contractDependencies": [
+          157
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "id": 130,
+        "linearizedBaseContracts": [
+          130,
+          157
+        ],
+        "name": "Proxy",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "constant": false,
+            "id": 87,
+            "name": "currentAddress",
+            "nodeType": "VariableDeclaration",
+            "scope": 130,
+            "src": "81:22:2",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 86,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "81:7:2",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "value": null,
+            "visibility": "internal"
+          },
+          {
+            "body": {
+              "id": 96,
+              "nodeType": "Block",
+              "src": "154:50:2",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 94,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "id": 92,
+                      "name": "currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 87,
+                      "src": "164:14:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 93,
+                      "name": "_currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 89,
+                      "src": "181:15:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "164:32:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 95,
+                  "nodeType": "ExpressionStatement",
+                  "src": "164:32:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 97,
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 90,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 89,
+                  "name": "_currentAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 97,
+                  "src": "122:23:2",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 88,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "122:7:2",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "121:25:2"
+            },
+            "returnParameters": {
+              "id": 91,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "154:0:2"
+            },
+            "scope": 130,
+            "src": "110:94:2",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 106,
+              "nodeType": "Block",
+              "src": "256:45:2",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 104,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "id": 102,
+                      "name": "currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 87,
+                      "src": "266:14:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 103,
+                      "name": "_newAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 99,
+                      "src": "283:11:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "266:28:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 105,
+                  "nodeType": "ExpressionStatement",
+                  "src": "266:28:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 107,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "upgrade",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 100,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 99,
+                  "name": "_newAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 107,
+                  "src": "228:19:2",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 98,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "228:7:2",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "227:21:2"
+            },
+            "returnParameters": {
+              "id": 101,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "256:0:2"
+            },
+            "scope": 130,
+            "src": "210:91:2",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 128,
+              "nodeType": "Block",
+              "src": "457:493:2",
+              "statements": [
+                {
+                  "assignments": [
+                    111
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 111,
+                      "name": "implementation",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 128,
+                      "src": "467:22:2",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 110,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "467:7:2",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "value": null,
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 113,
+                  "initialValue": {
+                    "argumentTypes": null,
+                    "id": 112,
+                    "name": "currentAddress",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 87,
+                    "src": "492:14:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "467:39:2"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 119,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "id": 115,
+                          "name": "currentAddress",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 87,
+                          "src": "524:14:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "arguments": [
+                            {
+                              "argumentTypes": null,
+                              "hexValue": "30",
+                              "id": 117,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "kind": "number",
+                              "lValueRequested": false,
+                              "nodeType": "Literal",
+                              "src": "550:1:2",
+                              "subdenomination": null,
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              },
+                              "value": "0"
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              }
+                            ],
+                            "id": 116,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "542:7:2",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": "address"
+                          },
+                          "id": 118,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "542:10:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address_payable",
+                            "typeString": "address payable"
+                          }
+                        },
+                        "src": "524:28:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 114,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        175,
+                        176
+                      ],
+                      "referencedDeclaration": 175,
+                      "src": "516:7:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 120,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "516:37:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 121,
+                  "nodeType": "ExpressionStatement",
+                  "src": "516:37:2"
+                },
+                {
+                  "assignments": [
+                    123
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 123,
+                      "name": "data",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 128,
+                      "src": "563:17:2",
+                      "stateVariable": false,
+                      "storageLocation": "memory",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes"
+                      },
+                      "typeName": {
+                        "id": 122,
+                        "name": "bytes",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "563:5:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_storage_ptr",
+                          "typeString": "bytes"
+                        }
+                      },
+                      "value": null,
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 126,
+                  "initialValue": {
+                    "argumentTypes": null,
+                    "expression": {
+                      "argumentTypes": null,
+                      "id": 124,
+                      "name": "msg",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 172,
+                      "src": "583:3:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_magic_message",
+                        "typeString": "msg"
+                      }
+                    },
+                    "id": 125,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "memberName": "data",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": null,
+                    "src": "583:8:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_calldata_ptr",
+                      "typeString": "bytes calldata"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "563:28:2"
+                },
+                {
+                  "externalReferences": [
+                    {
+                      "data": {
+                        "declaration": 123,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "730:4:2",
+                        "valueSize": 1
+                      }
+                    },
+                    {
+                      "data": {
+                        "declaration": 123,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "711:4:2",
+                        "valueSize": 1
+                      }
+                    },
+                    {
+                      "implementation": {
+                        "declaration": 111,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "691:14:2",
+                        "valueSize": 1
+                      }
+                    }
+                  ],
+                  "id": 127,
+                  "nodeType": "InlineAssembly",
+                  "operations": "{\n    let result := delegatecall(gas(), implementation, add(data, 0x20), mload(data), 0, 0)\n    let size := returndatasize()\n    let ptr := mload(0x40)\n    returndatacopy(ptr, 0, size)\n    switch result\n    case 0 {\n        revert(ptr, size)\n    }\n    default {\n        return(ptr, size)\n    }\n}",
+                  "src": "640:304:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 129,
+            "implemented": true,
+            "kind": "fallback",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 108,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "437:2:2"
+            },
+            "returnParameters": {
+              "id": 109,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "457:0:2"
+            },
+            "scope": 130,
+            "src": "429:521:2",
+            "stateMutability": "payable",
+            "superFunction": null,
+            "visibility": "external"
+          }
+        ],
+        "scope": 131,
+        "src": "50:902:2"
+      }
+    ],
+    "src": "0:952:2"
+  },
+  "legacyAST": {
+    "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Proxy.sol",
+    "exportedSymbols": {
+      "Proxy": [
+        130
+      ]
+    },
+    "id": 131,
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 82,
+        "literals": [
+          "solidity",
+          "^",
+          "0.5",
+          ".2"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "0:23:2"
+      },
+      {
+        "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
+        "file": "./Storage.sol",
+        "id": 83,
+        "nodeType": "ImportDirective",
+        "scope": 131,
+        "sourceUnit": 158,
+        "src": "25:23:2",
+        "symbolAliases": [],
+        "unitAlias": ""
+      },
+      {
+        "baseContracts": [
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 84,
+              "name": "Storage",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 157,
+              "src": "68:7:2",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Storage_$157",
+                "typeString": "contract Storage"
+              }
+            },
+            "id": 85,
+            "nodeType": "InheritanceSpecifier",
+            "src": "68:7:2"
+          }
+        ],
+        "contractDependencies": [
+          157
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "id": 130,
+        "linearizedBaseContracts": [
+          130,
+          157
+        ],
+        "name": "Proxy",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "constant": false,
+            "id": 87,
+            "name": "currentAddress",
+            "nodeType": "VariableDeclaration",
+            "scope": 130,
+            "src": "81:22:2",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 86,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "81:7:2",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "value": null,
+            "visibility": "internal"
+          },
+          {
+            "body": {
+              "id": 96,
+              "nodeType": "Block",
+              "src": "154:50:2",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 94,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "id": 92,
+                      "name": "currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 87,
+                      "src": "164:14:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 93,
+                      "name": "_currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 89,
+                      "src": "181:15:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "164:32:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 95,
+                  "nodeType": "ExpressionStatement",
+                  "src": "164:32:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 97,
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 90,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 89,
+                  "name": "_currentAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 97,
+                  "src": "122:23:2",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 88,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "122:7:2",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "121:25:2"
+            },
+            "returnParameters": {
+              "id": 91,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "154:0:2"
+            },
+            "scope": 130,
+            "src": "110:94:2",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 106,
+              "nodeType": "Block",
+              "src": "256:45:2",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 104,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "id": 102,
+                      "name": "currentAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 87,
+                      "src": "266:14:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 103,
+                      "name": "_newAddress",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 99,
+                      "src": "283:11:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "266:28:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 105,
+                  "nodeType": "ExpressionStatement",
+                  "src": "266:28:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 107,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "upgrade",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 100,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 99,
+                  "name": "_newAddress",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 107,
+                  "src": "228:19:2",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 98,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "228:7:2",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "227:21:2"
+            },
+            "returnParameters": {
+              "id": 101,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "256:0:2"
+            },
+            "scope": 130,
+            "src": "210:91:2",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 128,
+              "nodeType": "Block",
+              "src": "457:493:2",
+              "statements": [
+                {
+                  "assignments": [
+                    111
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 111,
+                      "name": "implementation",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 128,
+                      "src": "467:22:2",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 110,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "467:7:2",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "value": null,
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 113,
+                  "initialValue": {
+                    "argumentTypes": null,
+                    "id": 112,
+                    "name": "currentAddress",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 87,
+                    "src": "492:14:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "467:39:2"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 119,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "id": 115,
+                          "name": "currentAddress",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 87,
+                          "src": "524:14:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "arguments": [
+                            {
+                              "argumentTypes": null,
+                              "hexValue": "30",
+                              "id": 117,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "kind": "number",
+                              "lValueRequested": false,
+                              "nodeType": "Literal",
+                              "src": "550:1:2",
+                              "subdenomination": null,
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              },
+                              "value": "0"
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              }
+                            ],
+                            "id": 116,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "542:7:2",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": "address"
+                          },
+                          "id": 118,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "542:10:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address_payable",
+                            "typeString": "address payable"
+                          }
+                        },
+                        "src": "524:28:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 114,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        175,
+                        176
+                      ],
+                      "referencedDeclaration": 175,
+                      "src": "516:7:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 120,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "516:37:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 121,
+                  "nodeType": "ExpressionStatement",
+                  "src": "516:37:2"
+                },
+                {
+                  "assignments": [
+                    123
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 123,
+                      "name": "data",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 128,
+                      "src": "563:17:2",
+                      "stateVariable": false,
+                      "storageLocation": "memory",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes"
+                      },
+                      "typeName": {
+                        "id": 122,
+                        "name": "bytes",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "563:5:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_storage_ptr",
+                          "typeString": "bytes"
+                        }
+                      },
+                      "value": null,
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 126,
+                  "initialValue": {
+                    "argumentTypes": null,
+                    "expression": {
+                      "argumentTypes": null,
+                      "id": 124,
+                      "name": "msg",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 172,
+                      "src": "583:3:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_magic_message",
+                        "typeString": "msg"
+                      }
+                    },
+                    "id": 125,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "memberName": "data",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": null,
+                    "src": "583:8:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_calldata_ptr",
+                      "typeString": "bytes calldata"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "563:28:2"
+                },
+                {
+                  "externalReferences": [
+                    {
+                      "data": {
+                        "declaration": 123,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "730:4:2",
+                        "valueSize": 1
+                      }
+                    },
+                    {
+                      "data": {
+                        "declaration": 123,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "711:4:2",
+                        "valueSize": 1
+                      }
+                    },
+                    {
+                      "implementation": {
+                        "declaration": 111,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "691:14:2",
+                        "valueSize": 1
+                      }
+                    }
+                  ],
+                  "id": 127,
+                  "nodeType": "InlineAssembly",
+                  "operations": "{\n    let result := delegatecall(gas(), implementation, add(data, 0x20), mload(data), 0, 0)\n    let size := returndatasize()\n    let ptr := mload(0x40)\n    returndatacopy(ptr, 0, size)\n    switch result\n    case 0 {\n        revert(ptr, size)\n    }\n    default {\n        return(ptr, size)\n    }\n}",
+                  "src": "640:304:2"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 129,
+            "implemented": true,
+            "kind": "fallback",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 108,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "437:2:2"
+            },
+            "returnParameters": {
+              "id": 109,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "457:0:2"
+            },
+            "scope": 130,
+            "src": "429:521:2",
+            "stateMutability": "payable",
+            "superFunction": null,
+            "visibility": "external"
+          }
+        ],
+        "scope": 131,
+        "src": "50:902:2"
+      }
+    ],
+    "src": "0:952:2"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.5.8+commit.23d335f2.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "3.0.16",
+  "updatedAt": "2021-03-05T13:32:49.391Z",
+  "devdoc": {
+    "methods": {}
+  },
+  "userdoc": {
+    "methods": {}
+  }
+}

--- a/build/contracts/Storage.json
+++ b/build/contracts/Storage.json
@@ -30,36 +30,33 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.5.8+commit.23d335f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":true,\"inputs\":[],\"name\":\"_initialized\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":\"Storage\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":{\"keccak256\":\"0x89dacc345a67a37189c28a709477950ad5dfe7be2ddfff04c868fb19241a9444\",\"urls\":[\"bzzr://7b05bc88eb86b249580288d13d35cafecb19324c6b4f9bc031b4a12d8b944a13\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b50610104806100206000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80633072cf601460375780638da5cb5b146057575b600080fd5b603d609f565b604051808215151515815260200191505060405180910390f35b605d60b2565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a72305820baff6d3ed6c47870b41cb57999812d01ef5686123ac486308eb20c1ce07922a00029",
-  "deployedBytecode": "0x6080604052348015600f57600080fd5b506004361060325760003560e01c80633072cf601460375780638da5cb5b146057575b600080fd5b603d609f565b604051808215151515815260200191505060405180910390f35b605d60b2565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a72305820baff6d3ed6c47870b41cb57999812d01ef5686123ac486308eb20c1ce07922a00029",
-  "sourceMap": "34:282:2:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;34:282:2;;;;;;;",
-  "deployedSourceMap": "34:282:2:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;34:282:2;;;;;;;;;;;;;;;;;;;;;;;;287:24;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;265:20;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;287:24;;;;;;;;;;;;;:::o;265:20::-;;;;;;;;;;;;;:::o",
-  "source": "pragma solidity >=0.4.22 <0.9.0;\n\ncontract Storage {\nmapping (string => uint256) _uintStorage;\nmapping (string => address) _addressStorage;\nmapping (string => bool) _boolStorage;\nmapping (string => string) _stringStorage;\nmapping (string => bytes4) _bytes4Storage;\naddress public owner;\nbool public _initialized;\n\n\n}",
+  "metadata": "{\"compiler\":{\"version\":\"0.5.8+commit.23d335f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":true,\"inputs\":[],\"name\":\"_initialized\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":\"Storage\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol\":{\"keccak256\":\"0x1f47ada269b6e5d1cd53d5ceca0b2e77d55cc9b5c78b4f81607b5c942b56ad2e\",\"urls\":[\"bzzr://f26ea6721e2b8416eb7b48b59145fdbba66c881937b0ad3ad700cd8bdea0f514\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b50610104806100206000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80633072cf601460375780638da5cb5b146057575b600080fd5b603d609f565b604051808215151515815260200191505060405180910390f35b605d60b2565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a72305820eb5f95bf4954d83564cf0ad2e71e6c87e2e126cec290baa55dfae1377481fd8c0029",
+  "deployedBytecode": "0x6080604052348015600f57600080fd5b506004361060325760003560e01c80633072cf601460375780638da5cb5b146057575b600080fd5b603d609f565b604051808215151515815260200191505060405180910390f35b605d60b2565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600560149054906101000a900460ff1681565b600560009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea165627a7a72305820eb5f95bf4954d83564cf0ad2e71e6c87e2e126cec290baa55dfae1377481fd8c0029",
+  "sourceMap": "25:282:3:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:282:3;;;;;;;",
+  "deployedSourceMap": "25:282:3:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:282:3;;;;;;;;;;;;;;;;;;;;;;;;278:24;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;256:20;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;278:24;;;;;;;;;;;;;:::o;256:20::-;;;;;;;;;;;;;:::o",
+  "source": "pragma solidity ^0.5.2;\n\ncontract Storage {\nmapping (string => uint256) _uintStorage;\nmapping (string => address) _addressStorage;\nmapping (string => bool) _boolStorage;\nmapping (string => string) _stringStorage;\nmapping (string => bytes4) _bytes4Storage;\naddress public owner;\nbool public _initialized;\n\n\n}",
   "sourcePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
   "ast": {
     "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
     "exportedSymbols": {
       "Storage": [
-        107
+        157
       ]
     },
-    "id": 108,
+    "id": 158,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 82,
+        "id": 132,
         "literals": [
           "solidity",
-          ">=",
-          "0.4",
-          ".22",
-          "<",
-          "0.9",
-          ".0"
+          "^",
+          "0.5",
+          ".2"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:32:2"
+        "src": "0:23:3"
       },
       {
         "baseContracts": [],
@@ -67,20 +64,20 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 107,
+        "id": 157,
         "linearizedBaseContracts": [
-          107
+          157
         ],
         "name": "Storage",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "constant": false,
-            "id": 86,
+            "id": 136,
             "name": "_uintStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "53:40:2",
+            "scope": 157,
+            "src": "44:40:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -88,28 +85,28 @@
               "typeString": "mapping(string => uint256)"
             },
             "typeName": {
-              "id": 85,
+              "id": 135,
               "keyType": {
-                "id": 83,
+                "id": 133,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "62:6:2",
+                "src": "53:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "53:27:2",
+              "src": "44:27:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                 "typeString": "mapping(string => uint256)"
               },
               "valueType": {
-                "id": 84,
+                "id": 134,
                 "name": "uint256",
                 "nodeType": "ElementaryTypeName",
-                "src": "72:7:2",
+                "src": "63:7:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
@@ -121,11 +118,11 @@
           },
           {
             "constant": false,
-            "id": 90,
+            "id": 140,
             "name": "_addressStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "95:43:2",
+            "scope": 157,
+            "src": "86:43:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -133,28 +130,28 @@
               "typeString": "mapping(string => address)"
             },
             "typeName": {
-              "id": 89,
+              "id": 139,
               "keyType": {
-                "id": 87,
+                "id": 137,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "104:6:2",
+                "src": "95:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "95:27:2",
+              "src": "86:27:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_address_$",
                 "typeString": "mapping(string => address)"
               },
               "valueType": {
-                "id": 88,
+                "id": 138,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "114:7:2",
+                "src": "105:7:3",
                 "stateMutability": "nonpayable",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
@@ -167,11 +164,11 @@
           },
           {
             "constant": false,
-            "id": 94,
+            "id": 144,
             "name": "_boolStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "140:37:2",
+            "scope": 157,
+            "src": "131:37:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -179,28 +176,28 @@
               "typeString": "mapping(string => bool)"
             },
             "typeName": {
-              "id": 93,
+              "id": 143,
               "keyType": {
-                "id": 91,
+                "id": 141,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "149:6:2",
+                "src": "140:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "140:24:2",
+              "src": "131:24:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_bool_$",
                 "typeString": "mapping(string => bool)"
               },
               "valueType": {
-                "id": 92,
+                "id": 142,
                 "name": "bool",
                 "nodeType": "ElementaryTypeName",
-                "src": "159:4:2",
+                "src": "150:4:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_bool",
                   "typeString": "bool"
@@ -212,11 +209,11 @@
           },
           {
             "constant": false,
-            "id": 98,
+            "id": 148,
             "name": "_stringStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "179:41:2",
+            "scope": 157,
+            "src": "170:41:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -224,28 +221,28 @@
               "typeString": "mapping(string => string)"
             },
             "typeName": {
-              "id": 97,
+              "id": 147,
               "keyType": {
-                "id": 95,
+                "id": 145,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "188:6:2",
+                "src": "179:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "179:26:2",
+              "src": "170:26:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_string_storage_$",
                 "typeString": "mapping(string => string)"
               },
               "valueType": {
-                "id": 96,
+                "id": 146,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "198:6:2",
+                "src": "189:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
@@ -257,11 +254,11 @@
           },
           {
             "constant": false,
-            "id": 102,
+            "id": 152,
             "name": "_bytes4Storage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "222:41:2",
+            "scope": 157,
+            "src": "213:41:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -269,28 +266,28 @@
               "typeString": "mapping(string => bytes4)"
             },
             "typeName": {
-              "id": 101,
+              "id": 151,
               "keyType": {
-                "id": 99,
+                "id": 149,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "231:6:2",
+                "src": "222:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "222:26:2",
+              "src": "213:26:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_bytes4_$",
                 "typeString": "mapping(string => bytes4)"
               },
               "valueType": {
-                "id": 100,
+                "id": 150,
                 "name": "bytes4",
                 "nodeType": "ElementaryTypeName",
-                "src": "241:6:2",
+                "src": "232:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_bytes4",
                   "typeString": "bytes4"
@@ -302,11 +299,11 @@
           },
           {
             "constant": false,
-            "id": 104,
+            "id": 154,
             "name": "owner",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "265:20:2",
+            "scope": 157,
+            "src": "256:20:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -314,10 +311,10 @@
               "typeString": "address"
             },
             "typeName": {
-              "id": 103,
+              "id": 153,
               "name": "address",
               "nodeType": "ElementaryTypeName",
-              "src": "265:7:2",
+              "src": "256:7:3",
               "stateMutability": "nonpayable",
               "typeDescriptions": {
                 "typeIdentifier": "t_address",
@@ -329,11 +326,11 @@
           },
           {
             "constant": false,
-            "id": 106,
+            "id": 156,
             "name": "_initialized",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "287:24:2",
+            "scope": 157,
+            "src": "278:24:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -341,10 +338,10 @@
               "typeString": "bool"
             },
             "typeName": {
-              "id": 105,
+              "id": 155,
               "name": "bool",
               "nodeType": "ElementaryTypeName",
-              "src": "287:4:2",
+              "src": "278:4:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_bool",
                 "typeString": "bool"
@@ -354,35 +351,32 @@
             "visibility": "public"
           }
         ],
-        "scope": 108,
-        "src": "34:282:2"
+        "scope": 158,
+        "src": "25:282:3"
       }
     ],
-    "src": "0:316:2"
+    "src": "0:307:3"
   },
   "legacyAST": {
     "absolutePath": "/Users/peshangalo/Documents/Bachelor/Ivan of Tech/proxyContract/contracts/Storage.sol",
     "exportedSymbols": {
       "Storage": [
-        107
+        157
       ]
     },
-    "id": 108,
+    "id": 158,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 82,
+        "id": 132,
         "literals": [
           "solidity",
-          ">=",
-          "0.4",
-          ".22",
-          "<",
-          "0.9",
-          ".0"
+          "^",
+          "0.5",
+          ".2"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:32:2"
+        "src": "0:23:3"
       },
       {
         "baseContracts": [],
@@ -390,20 +384,20 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 107,
+        "id": 157,
         "linearizedBaseContracts": [
-          107
+          157
         ],
         "name": "Storage",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "constant": false,
-            "id": 86,
+            "id": 136,
             "name": "_uintStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "53:40:2",
+            "scope": 157,
+            "src": "44:40:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -411,28 +405,28 @@
               "typeString": "mapping(string => uint256)"
             },
             "typeName": {
-              "id": 85,
+              "id": 135,
               "keyType": {
-                "id": 83,
+                "id": 133,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "62:6:2",
+                "src": "53:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "53:27:2",
+              "src": "44:27:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_uint256_$",
                 "typeString": "mapping(string => uint256)"
               },
               "valueType": {
-                "id": 84,
+                "id": 134,
                 "name": "uint256",
                 "nodeType": "ElementaryTypeName",
-                "src": "72:7:2",
+                "src": "63:7:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
@@ -444,11 +438,11 @@
           },
           {
             "constant": false,
-            "id": 90,
+            "id": 140,
             "name": "_addressStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "95:43:2",
+            "scope": 157,
+            "src": "86:43:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -456,28 +450,28 @@
               "typeString": "mapping(string => address)"
             },
             "typeName": {
-              "id": 89,
+              "id": 139,
               "keyType": {
-                "id": 87,
+                "id": 137,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "104:6:2",
+                "src": "95:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "95:27:2",
+              "src": "86:27:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_address_$",
                 "typeString": "mapping(string => address)"
               },
               "valueType": {
-                "id": 88,
+                "id": 138,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "114:7:2",
+                "src": "105:7:3",
                 "stateMutability": "nonpayable",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
@@ -490,11 +484,11 @@
           },
           {
             "constant": false,
-            "id": 94,
+            "id": 144,
             "name": "_boolStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "140:37:2",
+            "scope": 157,
+            "src": "131:37:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -502,28 +496,28 @@
               "typeString": "mapping(string => bool)"
             },
             "typeName": {
-              "id": 93,
+              "id": 143,
               "keyType": {
-                "id": 91,
+                "id": 141,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "149:6:2",
+                "src": "140:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "140:24:2",
+              "src": "131:24:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_bool_$",
                 "typeString": "mapping(string => bool)"
               },
               "valueType": {
-                "id": 92,
+                "id": 142,
                 "name": "bool",
                 "nodeType": "ElementaryTypeName",
-                "src": "159:4:2",
+                "src": "150:4:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_bool",
                   "typeString": "bool"
@@ -535,11 +529,11 @@
           },
           {
             "constant": false,
-            "id": 98,
+            "id": 148,
             "name": "_stringStorage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "179:41:2",
+            "scope": 157,
+            "src": "170:41:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -547,28 +541,28 @@
               "typeString": "mapping(string => string)"
             },
             "typeName": {
-              "id": 97,
+              "id": 147,
               "keyType": {
-                "id": 95,
+                "id": 145,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "188:6:2",
+                "src": "179:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "179:26:2",
+              "src": "170:26:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_string_storage_$",
                 "typeString": "mapping(string => string)"
               },
               "valueType": {
-                "id": 96,
+                "id": 146,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "198:6:2",
+                "src": "189:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
@@ -580,11 +574,11 @@
           },
           {
             "constant": false,
-            "id": 102,
+            "id": 152,
             "name": "_bytes4Storage",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "222:41:2",
+            "scope": 157,
+            "src": "213:41:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -592,28 +586,28 @@
               "typeString": "mapping(string => bytes4)"
             },
             "typeName": {
-              "id": 101,
+              "id": 151,
               "keyType": {
-                "id": 99,
+                "id": 149,
                 "name": "string",
                 "nodeType": "ElementaryTypeName",
-                "src": "231:6:2",
+                "src": "222:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_string_storage_ptr",
                   "typeString": "string"
                 }
               },
               "nodeType": "Mapping",
-              "src": "222:26:2",
+              "src": "213:26:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_string_memory_$_t_bytes4_$",
                 "typeString": "mapping(string => bytes4)"
               },
               "valueType": {
-                "id": 100,
+                "id": 150,
                 "name": "bytes4",
                 "nodeType": "ElementaryTypeName",
-                "src": "241:6:2",
+                "src": "232:6:3",
                 "typeDescriptions": {
                   "typeIdentifier": "t_bytes4",
                   "typeString": "bytes4"
@@ -625,11 +619,11 @@
           },
           {
             "constant": false,
-            "id": 104,
+            "id": 154,
             "name": "owner",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "265:20:2",
+            "scope": 157,
+            "src": "256:20:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -637,10 +631,10 @@
               "typeString": "address"
             },
             "typeName": {
-              "id": 103,
+              "id": 153,
               "name": "address",
               "nodeType": "ElementaryTypeName",
-              "src": "265:7:2",
+              "src": "256:7:3",
               "stateMutability": "nonpayable",
               "typeDescriptions": {
                 "typeIdentifier": "t_address",
@@ -652,11 +646,11 @@
           },
           {
             "constant": false,
-            "id": 106,
+            "id": 156,
             "name": "_initialized",
             "nodeType": "VariableDeclaration",
-            "scope": 107,
-            "src": "287:24:2",
+            "scope": 157,
+            "src": "278:24:3",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -664,10 +658,10 @@
               "typeString": "bool"
             },
             "typeName": {
-              "id": 105,
+              "id": 155,
               "name": "bool",
               "nodeType": "ElementaryTypeName",
-              "src": "287:4:2",
+              "src": "278:4:3",
               "typeDescriptions": {
                 "typeIdentifier": "t_bool",
                 "typeString": "bool"
@@ -677,11 +671,11 @@
             "visibility": "public"
           }
         ],
-        "scope": 108,
-        "src": "34:282:2"
+        "scope": 158,
+        "src": "25:282:3"
       }
     ],
-    "src": "0:316:2"
+    "src": "0:307:3"
   },
   "compiler": {
     "name": "solc",
@@ -689,7 +683,7 @@
   },
   "networks": {},
   "schemaVersion": "3.0.16",
-  "updatedAt": "2021-03-05T11:51:14.966Z",
+  "updatedAt": "2021-03-05T13:19:39.115Z",
   "devdoc": {
     "methods": {}
   },

--- a/contracts/Cats.sol
+++ b/contracts/Cats.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.2;
+pragma solidity ^0.5.2;
 
 import "./Storage.sol";
 

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.2;
+pragma solidity ^0.5.2;
 
 import "./Storage.sol";
 

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.2;
+pragma solidity ^0.5.2;
 
 contract Storage {
 mapping (string => uint256) _uintStorage;

--- a/migrations/2_deploy_proxy.js
+++ b/migrations/2_deploy_proxy.js
@@ -1,0 +1,25 @@
+const Cats = artifacts.require('Cats'); // this is contract name, not file name.
+const Proxy = artifacts.require('Proxy');
+
+module.exports = async function(deployer, network, accounts){
+    // deploying the contract. deploying instance.
+    // await  because it is a aysinc function.
+    const cats = await Cats.new();
+    // Proxy constract need a address for the functional contract. In this case it is "cats".
+    const proxy = await Proxy.new(cats.address);
+
+    // Take Proxy source code.
+    //.at(): truffle function that create instance of Cats contract, but doing that
+    // from already exciting deployed contract "proxy"
+
+    // Fooling truffle by saying that we have a dog address lockated at "proxy.address"
+    // Set number of cats to 10
+    var proxyCat = await Cats.at(proxy.address);
+    proxyCat.setNumberOfCats(10);
+    // get the number of cats.
+    var nrOfCats = await proxyCat.getNumberOFCats();
+    //toNumber: to be readable.
+    console.log(nrOfCats.toNumber())
+
+    // in this way the data is saved in proxy contrcat and not in functional contract.
+}


### PR DESCRIPTION
- Deploying the contract instance.
- Fooling truffle to use proxy contract, instead of the functional one.
- in this way, all the data will be saved in the proxy contract, and the functional contract will be used only to do functional things.